### PR TITLE
Learning Outcomes Formatting

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -118,6 +118,10 @@ textarea {
 
 /* LEARNING_OUTCOMES.EJS STYLES ***********************************************/
 
+h3 > p {
+    font-size: 0.5em;
+}
+
 .high_priority {
     color: white;
     background-color: black;

--- a/views/includes/navbar.ejs
+++ b/views/includes/navbar.ejs
@@ -10,6 +10,9 @@
                 <a class="nav-link" href="/programs">Programs</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/learning_outcomes">Learning Outcomes Timeline</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/dis-form">Discussion Form</a>
             </li>
              <li class="nav-item">
@@ -17,9 +20,6 @@
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="/updates">Updates</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="/learning_outcomes">Learning Outcomes Timeline</a>
             </li>
         </ul>
 </nav>

--- a/views/learning_outcomes.ejs
+++ b/views/learning_outcomes.ejs
@@ -12,12 +12,17 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
     High Priority PLOs
     <p class="mb-0 pt-2">Program Learning Outcomes that are overdue for an update</p>
 </h3>
-<table id="plo-table-1" class="table table-dark outcome_table collapse">
+<table id="plo-table-1" class="w-100 table table-dark outcome_table collapse">
     <thead>
-        <th>Outcome ID</th>
-        <th>Program</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-5">Program</th>
+        <th class="col-2">Last Updated</th>
+        <th class="col-2">Update By</th>
+        <!-- This filler column has been added as a messy fix for a problem 
+        where the table rows would not expand to fill the table container unless
+        they were wider than the container. Cause unknown, but possibly related
+        to the .collapse class -->
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <!-- row_counter lets me assign a unique id to each row -->
@@ -25,7 +30,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
         <% let row_counter = 0 %>
         <% for (let outcome of PLOs_1) { %>
             <!-- Outcome description is collapsible; click anywhere on the row to toggle -->
-            <tr data-toggle="collapse" data-target="#pt1-desc-<%=row_counter%>">
+            <tr class="w-100" data-toggle="collapse" data-target="#pt1-desc-<%=row_counter%>">
                 <td><%=outcome.outcome_id%></td>
                 <td>
                     <a href="/programs/<%=outcome.domain_id%>">
@@ -42,10 +47,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt1-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>
@@ -60,10 +66,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 </h3>
 <table id="clo-table-1" class="table table-dark outcome_table collapse">
     <thead>
-        <th>Outcome ID</th>
-        <th>Course</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-5">Course</th>
+        <th class="col-2">Last Updated</th>
+        <th class="col-2">Update By</th>
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <% row_counter = 0 %>
@@ -81,10 +88,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct1-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>
@@ -99,10 +107,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 </h3>
 <table id="plo-table-2" class="table table-dark outcome_table collapse">
     <thead>
-        <th>Outcome ID</th>
-        <th>Program</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-5">Program</th>
+        <th class="col-2">Last Updated</th>
+        <th class="col-2">Update By</th>
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <% row_counter = 0 %>
@@ -124,10 +133,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt2-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>
@@ -142,10 +152,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 </h3>
 <table id="clo-table-2" class="table table-dark outcome_table collapse">
     <thead>
-        <th>Outcome ID</th>
-        <th>Course</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-3">Course</th>
+        <th class="col-3">Last Updated</th>
+        <th class="col-3">Update By</th>
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <% row_counter = 0 %>
@@ -163,10 +174,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct2-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>
@@ -181,10 +193,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 </h3>
 <table id="plo-table-3" class="table table-dark collapse outcome_table">
     <thead>
-        <th>Outcome ID</th>
-        <th>Program</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-5">Program</th>
+        <th class="col-2">Last Updated</th>
+        <th class="col-2">Update By</th>
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <% row_counter = 0 %>
@@ -206,10 +219,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt3-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>
@@ -224,10 +238,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 </h3>
 <table id="clo-table-3" class="table table-dark collapse outcome_table">
     <thead>
-        <th>Outcome ID</th>
-        <th>Course</th>
-        <th>Last Updated</th>
-        <th>Update By</th>
+        <th class="col-3">Outcome ID</th>
+        <th class="col-5">Course</th>
+        <th class="col-2">Last Updated</th>
+        <th class="col-2">Update By</th>
+        <th class="col-0"></th>
     </thead>
     <tbody>
         <% row_counter = 0 %>
@@ -245,10 +260,11 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                     <%= outcome.next_update.getDate() %>,
                     <%= outcome.next_update.getFullYear() %>
                 </td>
+                <td></td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct3-desc-<%=row_counter%>" class="collapse">
-                <td colspan="4"><%=outcome.outcome_description%></td>
+                <td colspan="5"><%=outcome.outcome_description%></td>
             </tr>
             <% row_counter += 1 %>
         <% } %>

--- a/views/learning_outcomes.ejs
+++ b/views/learning_outcomes.ejs
@@ -3,6 +3,8 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 
 <h1 class="py-2 pt-5">Learning Outcomes Timeline</h2>
 
+<% const months = ["Jan", "Feb", "March", "April", "May", "June", "July", "Aug",
+                   "Sept", "Oct", "Nov", "Dec"] %>
 
 <!-- PLOs that are overdue for an update -->
 <!-- Table is collapsible; click here to toggle -->
@@ -30,8 +32,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                         <%=outcome.domain_name%>
                     </a>
                 </td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt1-desc-<%=row_counter%>" class="collapse">
@@ -61,8 +71,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
             <tr data-toggle="collapse" data-target="#ct1-desc-<%=row_counter%>">
                 <td><%=outcome.outcome_id%></td>
                 <td><%=outcome.domain_name%></td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct1-desc-<%=row_counter%>" class="collapse">
@@ -96,8 +114,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                         <%=outcome.domain_name%>
                     </a>
                 </td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt2-desc-<%=row_counter%>" class="collapse">
@@ -127,8 +153,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
             <tr data-toggle="collapse" data-target="#ct2-desc-<%=row_counter%>">
                 <td><%=outcome.outcome_id%></td>
                 <td><%=outcome.domain_name%></td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct2-desc-<%=row_counter%>" class="collapse">
@@ -162,8 +196,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
                         <%=outcome.domain_name%>
                     </a>
                 </td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="pt3-desc-<%=row_counter%>" class="collapse">
@@ -193,8 +235,16 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
             <tr data-toggle="collapse" data-target="#ct3-desc-<%=row_counter%>">
                 <td><%=outcome.outcome_id%></td>
                 <td><%=outcome.domain_name%></td>
-                <td><%=outcome.last_updated%></td>
-                <td><%=outcome.next_update%></td>
+                <td>
+                    <%= months[outcome.last_updated.getMonth()] %>
+                    <%= outcome.last_updated.getDate() %>,
+                    <%= outcome.last_updated.getFullYear() %>
+                </td>
+                <td>
+                    <%= months[outcome.next_update.getMonth()] %>
+                    <%= outcome.next_update.getDate() %>,
+                    <%= outcome.next_update.getFullYear() %>
+                </td>
             </tr>
             <!-- Collapsible description spans entire row -->
             <tr id="ct3-desc-<%=row_counter%>" class="collapse">

--- a/views/learning_outcomes.ejs
+++ b/views/learning_outcomes.ejs
@@ -8,6 +8,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- Table is collapsible; click here to toggle -->
 <h3 class="mt-5 mb-0 p-2 high_priority" data-toggle="collapse" data-target="#plo-table-1">
     High Priority PLOs
+    <p class="mb-0 pt-2">Program Learning Outcomes that are overdue for an update</p>
 </h3>
 <table id="plo-table-1" class="table table-dark outcome_table collapse">
     <thead>
@@ -45,6 +46,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- CLOs that are overdue for an update -->
 <h3 class="mt-5 mb-0 p-2 high_priority" data-toggle="collapse" data-target="#clo-table-1">
     High Priority CLOs
+    <p class="mb-0 pt-2">Course Learning Outcomes that are overdue for an update</p>
 </h3>
 <table id="clo-table-1" class="table table-dark outcome_table collapse">
     <thead>
@@ -75,6 +77,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- PLOs that should be updated within the year -->
 <h3 class="mt-5 mb-0 p-2 med_priority" data-toggle="collapse" data-target="#plo-table-2">
     Medium Priority PLOs
+    <p class="mb-0 pt-2">Program Learning Outcomes that should be updated within the year</p>
 </h3>
 <table id="plo-table-2" class="table table-dark outcome_table collapse">
     <thead>
@@ -109,6 +112,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- CLOs that should be updated within the year -->
 <h3 class="mt-5 mb-0 p-2 med_priority" data-toggle="collapse" data-target="#clo-table-2">
     Medium Priority CLOs
+    <p class="mb-0 pt-2">Course Learning Outcomes that should be updated within the year</p>
 </h3>
 <table id="clo-table-2" class="table table-dark outcome_table collapse">
     <thead>
@@ -139,6 +143,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- PLOs that have more than a year until they need to be updated -->
 <h3 class="mt-5 mb-0 p-2 low_priority" data-toggle="collapse" data-target="#plo-table-3">
     Low Priority PLOs
+    <p class="mb-0 pt-2">Program Learning Outcomes that do not need to be updated for at least a year</p>
 </h3>
 <table id="plo-table-3" class="table table-dark collapse outcome_table">
     <thead>
@@ -173,6 +178,7 @@ date they were last updated. Data is aquired from learning_outcomes.js. -->
 <!-- CLOs that have more than a year until they need to be updated -->
 <h3 class="mt-5 mb-0 p-2 low_priority" data-toggle="collapse" data-target="#clo-table-3">
     Low Priority CLOs
+    <p class="mb-0 pt-2">Course Learning Outcomes that do not need to be updated for at least a year</p>
 </h3>
 <table id="clo-table-3" class="table table-dark collapse outcome_table">
     <thead>

--- a/views/single_reports.ejs
+++ b/views/single_reports.ejs
@@ -22,11 +22,14 @@
 
 <p class="text-dark pb-5"><%= assessment.notes %> </p>
 
-<!-- DATE DISPLAYED AS YYYY-MM-DD -->
+<!-- DATE DISPLAYED AS MONTH D, YYYY -->
+<% const months = ["Jan", "Feb", "March", "April", "May", "June", "July", "Aug",
+                   "Sept", "Oct", "Nov", "Dec"] %>
+                   
 <p class="text-dark"><b>Submission Date: </b>
-    <%= assessment.date_assessed.getFullYear() %>-<!--
-    --><%= assessment.date_assessed.getMonth() %>-<!--
-    --><%= assessment.date_assessed.getDate() %>
+    <%= months[assessment.date_assessed.getMonth()] %>
+    <%= assessment.date_assessed.getDate() %>,
+    <%= assessment.date_assessed.getFullYear() %>
 </p>
 
 <p class="text-dark"><b>Submitted By: </b><%= assessment.discussion_completed_by %> </p>


### PR DESCRIPTION
- Changed the order of links on the nav bar
- Re-formatted dates on the learning outcomes page, as well as the individual report pages
- Resolved (messily) an issue where table rows would not expand to fill the table width on the learning outcomes page. I suspect the issue is caused by the way Bootstrap's .collapse and .table classes interact; possibly the problem could be better resolved by writing a custom collapse toggle.